### PR TITLE
update isPromise guard

### DIFF
--- a/packages/locator/src/lib/stacktrace-locator.ts
+++ b/packages/locator/src/lib/stacktrace-locator.ts
@@ -6,10 +6,10 @@ import {
   LEAST_UPPER_BOUND,
 } from './source-map';
 import ErrorStackParser from 'error-stack-parser';
-import { PromiseOrValue } from '@rxjs-insights/core/src/lib/locator';
+import { PromiseOrValue } from '@rxjs-insights/core';
 
 function isPromise<T>(x: PromiseOrValue<T>): x is Promise<T> {
-  return 'then' in x && 'catch' in x;
+  return Boolean(x) && 'then' in x && 'catch' in x;
 }
 
 export class StacktraceLocator implements Locator {


### PR DESCRIPTION
The StacktraceLocator class has a method getOriginalLocation that may return an undefined.
The locate method uses a value returned by getOriginalLocation and passes it through a guard isPromise.
However, the isPromise guard doesn't have a check if the value is not undefined, even though the getOriginalLocation method may return an undefined.
Therefore, if getOriginalLocation returns an undefined location, we end up getting an error like "Cannot use 'in' operator to search for 'then' in undefined".